### PR TITLE
Update docs, add Flow class

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,126 +5,11 @@ Personable chatbot for [Slack](https://slack.com/) using the [Slack Realtime Mes
 Features
 --------
 
-* **Test mode with simulated chat** in the command line: test Botty and Botty plugins offline, without using Slack at all.
+* **Test mode with simulated chat** in the command line: try Botty and Botty plugins offline, without using Slack at all.
 * In-process **Python REPL**: monitor, patch, or control running Botty instances **without restarting** or editing files.
 * Simple and reliable: Botty gracefully handles **plugin exceptions**, **network issues**, and more.
 * Robust **plugin API**: friendly error messages and well-documented functions makes development fast and productive - each plugin is simply a Python class.
 * Excellent **Slack protocol compliance**: supports periodic ping, message escape sequences, and more, on top of the official Slack Python library.
-
-Writing Plugins
----------------
-
-### Overview
-
-Botty plugins are simply Python classes. By convention, we organize these onto one class per file, and put these files under the `src/plugins` directory. There's an example in the "Types of Text" section below.
-
-Plugin classes should inherit from `BasePlugin` (from `src/plugins/utilities.py`).
-
-Plugin classes can optionally implement the `on_step()` method, which is called on every time step (except in the situation described below) - generally several times a second. For multiple plugins, the `on_step` methods are called in the order that the plugins are registered.
-
-If an plugin's `on_step` method returns a truthy value, all plugins after it will not have their `on_step` method called for that time step - returning a truthy value stops step processing for the current time step.
-
-Plugin classes can optionally implement the `on_message(message)` method, which is called upon receiving a message (except in the situation described below). For multiple plugins, the `on_message` methods are called in the order that the plugins are registered, and always after `on_step` methods have been called.
-
-The `message` in `on_message(message)` is a JSON dictionary representing a Slack event. The format of this dictionary is documented in the [Slack API documentation](https://api.slack.com/rtm), under the "Events" section. Generally, we only care about the [message event](https://api.slack.com/events/message).
-
-However, it is a good idea to avoid accessing fields of the JSON dictionary directly if possible; if these change in the future, your code could break. If you just need the text, channel, or sender, use the `self.get_message_text`, `self.get_message_channel`, and `self.get_message_sender` methods instead.
-
-If an plugin's `on_message` method returns a truthy value, all plugins after it will not have their `on_message` method called for that message - returning a truthy value stops message processing for the current message, representing that the message has been fully handled.
-
-Plugins can interact with messages easily using the `self.say` (say something) and `self.react` (react to a message) methods. In message handlers, the `self.respond` (respond to the most recent message) and `sely.reply` (react to the most recent message) methods can be used instead, which are a bit easier to use.
-
-### API
-
-Plugins inherit a number of methods from the `BasePlugin` class:
-
-* `self.untag_word(word)` - returns the word `word` where characters are replaced with Unicode homoglyphs such that they are unlikely to highlight users.
-    * Useful for if you want to send a user's name without highlighting them.
-* `self.get_message_text(message)` - returns the text value of `message` if it is a valid text message, or `None` otherwise.
-* `self.get_message_timestamp(message)` - returns the timestamp of `message` if there is one, or `None` otherwise.
-* `self.get_message_channel(message)` - returns the ID of the channel containing `message` if there is one, or `None` otherwise.
-* `self.get_message_sender(message)` - returns the ID of the user who sent `message` if there is one, or `None` otherwise.
-* `self.say(channel_id, sendable_text)` - send a message containing `sendable_text` to the channel with ID `channel_id`.
-    * `sendable_text` must be sendable text (see "Types of Text" for details).
-    * Plain text can be converted into sendable text using `self.text_to_sendable_text`.
-    * Returns a message ID (used internally, unique to every `SlackBot` instance).
-* `self.say_raw(channel_id, text)` - same as `self.say`, but `text` is plain text instead of sendable text.
-* `self.say_complete(channel_id, text)` and `self.say_complete(channel_id, text)` - same as `self.say` and `self.say_raw`, but waits for the message to fully send before returning.
-    * Returns the message timestamp.
-    * Raises a `TimeoutError` if sending times out, or a `ValueError` if sending fails.
-* `self.respond(sendable_text)` - does the same thing as `self.say`, but always sends the message to the channel of the message we most recently processed.
-    * If this is called within an `on_message(message)` handler, the message will always be sent to the same channel as the one containing `message`.
-* `self.respond_raw(text)` - same as `self.respond`, but `text` is plain text instead of sendable text.
-* `self.respond_complete(sendable_text)` and `self.respond_raw_complete(text)` - same as `self.respond` and `self.respond_raw`, but waits for the message to fully send before returning.
-    * Returns the message timestamp.
-    * Raises a `TimeoutError` if sending times out, or a `ValueError` if sending fails.
-* `react(channel_id, timestamp, emoticon)` - react with `emoticon` to the message with timestamp `timestamp` in channel with ID `channel_id`.
-* `unreact(channel_id, timestamp, emoticon)` - unreact with `emoticon` to the message with timestamp `timestamp` in channel with ID `channel_id`.
-* `reply(emoticon)` - react with `emoticon` to the most recently received message.
-    * If this is called within an `on_message(message)` handler, the reaction will be to `message`.
-* `unreply(emoticon)` - unreact with `emoticon` to the most recently received message.
-    * If this is called within an `on_message(message)` handler, the reaction will be to `message`.
-* `self.get_channel_name_by_id(channel_id)` - returns the name of the channel with ID `channel_id`, or `None` if there are no channels with that ID. Channels include public channels, direct messages with other users, and private groups.
-    * Channels include public channels, direct messages with other users, and private groups.
-* `self.get_channel_id_by_name(channel_name)` - returns the ID of the channel with name `channel_name`, or `None` if there are no channels with that name. Channels include public channels, direct messages with other users, and private groups.
-    * Channels include public channels, direct messages with other users, and private groups.
-* `self.get_user_name_by_id(user_id)` - returns the username of the user with ID `user_id`, or `None` if there are no users with that ID.
-* `self.get_user_id_by_name(user_id)` - returns the ID of the user with username `user_name`, or `None` if there are no users with that username.
-* `self.get_direct_message_channel_id_by_user_id(user_id)` - returns the channel ID of the direct message with the user with ID `user_id`, or `None` if the ID is invalid.
-* `self.get_user_info_by_id(user_id)` - returns a [metadata dictionary](https://api.slack.com/types/user) about the user with ID `user_id`.
-* `self.text_to_sendable_text(text)` - returns `text`, a plain text string, converted into sendable text.
-* `self.sendable_text_to_text(sendable_text)` - returns `sendable_text`, a sendable text string, converted into plain text.
-    * The transformation can lose some information for escape sequences, such as link labels.
-* `self.get_bot_user_id()` - returns the user ID of the current `SlackBot` instance's Slack account.
-
-Plugins are registered in `src/botty.py`. Suppose you have a plugin called `TestPlugin` (in other words, a class called `TestPlugin`) in `src/plugins/test.py`. Then, in `src/botty.py`, you would add the following with the other plugin imports:
-
-```python
-from plugins.test import TestPlugin
-botty.register_plugin(TestPlugin(botty))
-```
-
-### Types of Text
-
-There are actually three different formats for text in Slack messages:
-
-* **Sendable format** is the format of text that is suitable for sending as the body of messages in the Slack API, such as for message contents.
-    * **Sendable text** is text that follows the sendable format.
-    * Sendable text should generally be considered opaque, since you generally won't want to go through the effort of dealing with the syntax.
-    * The main difference between sendable text and server text is that sendable text has bare links, while server text surrounds links with `<` and `>`.
-    * That means that if you send server text instead of sendable text, links will have angle brackets around them.
-* **Plain format** is the lack of any fixed format.
-    * **Plain text** is text that has no fixed format - it can contain anything.
-    * The main difference between plain text and sendable text is that sendable text has the `<`, `>`, and `&` characters HTML-escaped, while plain text does not.
-* **Server format** is the format of text received from the Slack API, such as for message contents.
-    * **Server text** is text that follows server format.
-    * Plugins generally don't have to care about server text because functions in the plugin API that deal with text will return either sendable or plain text.
-
-Sendable text should be used for sending parts of Slack messages that we receive, and plain text should be used for everything else. This is because **sendable text can represent more information than plain text can**, such as channel/user references, links, and more. Therefore, **converting sendable text to plain text will lose this extra information**.
-
-However, **sendable text has special formatting that needs to be explicitly handled in code**. For things like sending the text to a search engine as a query, it is better to send the plain text version, since it will not have any of the special formatting.
-
-Suppose we have a plugin that attempts to evaluate all messages as Python code and responds with the results:
-
-```python
-from .utilities import BasePlugin
-class ArithmeticPlugin(BasePlugin):
-    def __init__(self, bot):
-        super().__init__(bot)
-
-    def on_message(self, message):
-        sendable_text = self.get_message_text(message)
-        if sendable_text is None: return False
-        text = self.sendable_text_to_text(sendable_text) # convert sendable text to plain text
-
-        try: result = str(eval(text)) # we evaluate the plain text `text` rather than the sendable text `sendable_text`
-        except Exception as e: result = str(e)
-        sendable_result = self.text_to_sendable_text(result)
-
-        # we send `sendable_text` instead of `text` to preserve sendable formatting that is lost when converting sendable text to plain text
-        self.respond("{} :point_right: {}".format(sendable_text, sendable_result))
-        return True
-```
 
 Deployment
 ----------
@@ -137,103 +22,21 @@ To run in production mode, run `python3 src/botty.py SLACK_API_TOKEN_GOES_HERE`,
 
 Currently, a Botty instance is deployed for [nokappa.slack.com](https://nokappa.slack.com/) on DigitalOcean inside a [tmux](https://tmux.github.io/) session, to allow monitoring and management over SSH. Code updates are done via Git.
 
-Files Overview
---------------
+Developing Botty
+----------------
 
-### `src/botty.py`
+See the "Deployment" section for information about setting up an environment suitable for developing Botty with.
 
-The entry point for Botty. Implements plugin loading and handling on top of the Slack bot functionality implemented in `src/bot.py`, as well as a few utility functions that are useful for developing plugins.
+Botty ships with several plugins by default, some of which require API keys or take some time to start. If you don't need those plugins, simply comment out the relevant lines in the body of the `initialize_plugins` function in `src/botty.py` to disable them.
 
-`example-start-botty.sh` is a Bash script that shows a sample usage of `src/botty.py`. If you edit the script to replace `SLACK_API_TOKEN_GOES_HERE` with an actual API token, you can start Botty simply by running it.
+See the [code reference](https://github.com/Uberi/botty-bot-bot-bot/blob/master/docs/reference.md) for API documentation, project file layout, and more.
 
-    $ python3 src/botty.py --help
-    Usage: ./botty.py --help
-        Show this help message
-    Usage: ./botty.py
-        Start the Botty chatbot for Slack in testing mode with a console chat interface
-    Usage: ./botty.py SLACK_BOT_TOKEN
-        Start the Botty chatbot for the Slack chat associated with SLACK_BOT_TOKEN, and enter the in-process Python REPL
-        SLACK_BOT_TOKEN is a Slack API token (can be obtained from https://api.slack.com/)
-
-### `src/bot.py`
-
-Implements Slack bot functionality, such as receiving/sending messages, managing the connection to the Slack Realtime Messaging API, looking up users/channels, parsing message formatting/escape sequences, and more. This is encapsulated in the `SlackBot` class, which is intended to be extended to make custom Slack bots.
-
-Also implements a mock Slack bot in the `SlackDebugBot` class, which exposes the same interface as `SlackBot`, but all functionality acts on a simulated Slack chat in the terminal. Replacing `SlackBot` with `SlackDebugBot` allows testing and local development without using the real Slack API at all.
-
-### `src/plugins/*`
-
-Folder in which plugins reside. Each plugin is an importable Python module - a `*.py` file, or a folder containing `__init__.py` as a direct child.
-
-The plugins are imported and registered in `src/botty.py`.
-
-Botty ships with several default plugins. For more information about what they do and how they work, look at their docstrings and source code.
-
-For general information about writing plugins, see the "Writing Plugins" section.
-
-### `utils/download-history.py`
-
-`utils/download-history.py` is a standalone utility that downloads history from all channels in the Slack team associated with a given API token.
-
-If previously downloaded history is present, the new history will be transparently appended to the old history.
-
-    $ python3 src/download-history.py
-    Usage: download-history.py SLACK_API_TOKEN [SAVE_FOLDER]
-        SLACK_API_TOKEN    Slack API token (obtainable from https://api.slack.com/tokens)
-        SAVE_FOLDER        Folder to save messages in (defaults to ./@history)
-
-`example-download-history.sh` is a Bash script that shows a sample usage of this utility. If you edit the script to replace `SLACK_API_TOKEN_GOES_HERE` with an actual Slack API token, you can download history simply by running it.
-
-### `utils/process-history.py`
-
-`utils/process-history.py` is a standalone utility that processes and shows history in-memory. With a variety of filtering options, it is very useful for searching through and filtering messages.
-
-    $ python3 src/process-history.py --help
-    usage: process-history.py [-h] [--history HISTORY] [-f FILTER_FROM]
-                              [-t FILTER_TO] [-c FILTER_CHANNEL] [-u FILTER_USER]
-                              [-i FILTER_TEXT] [-s {time,channel,user,text}]
-                              [-r CONTEXT]
-    
-    Slice and filter Slack chat history.
-    
-    optional arguments:
-      -h, --help            show this help message and exit
-      --history HISTORY     Directory to look for JSON chat history files in
-                            (e.g., "~/.slack-history").
-      -f FILTER_FROM, --filter-from FILTER_FROM
-                            Show only messages at or after a date/time (e.g., "4pm
-                            september 8 2015").
-      -t FILTER_TO, --filter-to FILTER_TO
-                            Show only messages before or at a date/time (e.g.,
-                            "8pm september 9 2015").
-      -c FILTER_CHANNEL, --filter-channel FILTER_CHANNEL
-                            Show only messages within channels with names matching
-                            a specific regular expression (e.g., "general",
-                            "general|random").
-      -u FILTER_USER, --filter-user FILTER_USER
-                            Show only messages by users with usernames or real
-                            names matching a specific regular expression (e.g.,
-                            "anthony", "[AO]nthon[yo] Zh[ao]ng").
-      -i FILTER_TEXT, --filter-text FILTER_TEXT
-                            Show only messages with text matching a specified
-                            regular expression (e.g., "wings?",
-                            "chicken\s+nuggets").
-      -s {time,channel,user,text}, --sort {time,channel,user,text}
-                            Sort the resulting messages by the specified criteria.
-      -r CONTEXT, --context CONTEXT
-                            Show a specified number of surrounding messages around
-                            the channel in each matched message.
-
-`example-process-history.sh` is a Bash script that shows a sample usage of this utility, filtering out messages in the channel `#general` that include the phrase "wing night" or "nuggets", sorted alphabetically by username.
-
-### `utils/export-history-to-db.py`
-
-`utils/export-history-to-db.py` is a standalone utility that, when run, exports an entire history directory (downloaded using something like `utils/download-history.py`) to a single Sqlite3 database, defaulting to `history.db` in the same directory as the script.
+See the [plugin writing guide](https://github.com/Uberi/botty-bot-bot-bot/blob/master/docs/writing-plugins.md) for information about how to develop your own Botty plugins.
 
 License
 -------
 
-Copyright 2015-2016 [Anthony Zhang (Uberi)](https://uberi.github.io).
+Copyright 2015-2016 [Anthony Zhang (Uberi)](https://anthony-zhang.me).
 
 The source code is available online at [GitHub](https://github.com/Uberi/botty-bot-bot-bot).
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,139 @@
+Code Reference
+==============
+
+Plugin API
+----------
+
+Plugins inherit a number of methods from the `BasePlugin` class in `src/plugins/utilities.py`:
+
+* `self.untag_word(word)` - returns the word `word` where characters are replaced with Unicode homoglyphs such that they are unlikely to highlight users.
+    * Useful for if you want to send a user's name without highlighting them.
+* `self.get_message_text(message)` - returns the text value of `message` if it is a valid text message, or `None` otherwise.
+* `self.get_message_timestamp(message)` - returns the timestamp of `message` if there is one, or `None` otherwise.
+* `self.get_message_channel(message)` - returns the ID of the channel containing `message` if there is one, or `None` otherwise.
+* `self.get_message_sender(message)` - returns the ID of the user who sent `message` if there is one, or `None` otherwise.
+* `self.say(channel_id, sendable_text)` - send a message containing `sendable_text` to the channel with ID `channel_id`.
+    * `sendable_text` must be sendable text (see "Types of Text" for details).
+    * Plain text can be converted into sendable text using `self.text_to_sendable_text`.
+    * Returns a message ID (used internally, unique to every `SlackBot` instance).
+* `self.say_raw(channel_id, text)` - same as `self.say`, but `text` is plain text instead of sendable text.
+* `self.say_complete(channel_id, text)` and `self.say_complete(channel_id, text)` - same as `self.say` and `self.say_raw`, but waits for the message to fully send before returning.
+    * Returns the message timestamp.
+    * Raises a `TimeoutError` if sending times out, or a `ValueError` if sending fails.
+* `self.respond(sendable_text)` - does the same thing as `self.say`, but always sends the message to the channel of the message we most recently processed.
+    * If this is called within an `on_message(message)` handler, the message will always be sent to the same channel as the one containing `message`.
+* `self.respond_raw(text)` - same as `self.respond`, but `text` is plain text instead of sendable text.
+* `self.respond_complete(sendable_text)` and `self.respond_raw_complete(text)` - same as `self.respond` and `self.respond_raw`, but waits for the message to fully send before returning.
+    * Returns the message timestamp.
+    * Raises a `TimeoutError` if sending times out, or a `ValueError` if sending fails.
+* `react(channel_id, timestamp, emoticon)` - react with `emoticon` to the message with timestamp `timestamp` in channel with ID `channel_id`.
+* `unreact(channel_id, timestamp, emoticon)` - unreact with `emoticon` to the message with timestamp `timestamp` in channel with ID `channel_id`.
+* `reply(emoticon)` - react with `emoticon` to the most recently received message.
+    * If this is called within an `on_message(message)` handler, the reaction will be to `message`.
+* `unreply(emoticon)` - unreact with `emoticon` to the most recently received message.
+    * If this is called within an `on_message(message)` handler, the reaction will be to `message`.
+* `self.get_channel_name_by_id(channel_id)` - returns the name of the channel with ID `channel_id`, or `None` if there are no channels with that ID. Channels include public channels, direct messages with other users, and private groups.
+    * Channels include public channels, direct messages with other users, and private groups.
+* `self.get_channel_id_by_name(channel_name)` - returns the ID of the channel with name `channel_name`, or `None` if there are no channels with that name. Channels include public channels, direct messages with other users, and private groups.
+    * Channels include public channels, direct messages with other users, and private groups.
+* `self.get_user_name_by_id(user_id)` - returns the username of the user with ID `user_id`, or `None` if there are no users with that ID.
+* `self.get_user_id_by_name(user_id)` - returns the ID of the user with username `user_name`, or `None` if there are no users with that username.
+* `self.get_direct_message_channel_id_by_user_id(user_id)` - returns the channel ID of the direct message with the user with ID `user_id`, or `None` if the ID is invalid.
+* `self.get_user_info_by_id(user_id)` - returns a [metadata dictionary](https://api.slack.com/types/user) about the user with ID `user_id`.
+* `self.text_to_sendable_text(text)` - returns `text`, a plain text string, converted into sendable text.
+* `self.sendable_text_to_text(sendable_text)` - returns `sendable_text`, a sendable text string, converted into plain text.
+    * The transformation can lose some information for escape sequences, such as link labels.
+* `self.get_bot_user_id()` - returns the user ID of the current `SlackBot` instance's Slack account.
+
+Files Overview
+--------------
+
+### `src/botty.py`
+
+The entry point for Botty. Implements plugin loading and handling on top of the Slack bot functionality implemented in `src/bot.py`, as well as a few utility functions that are useful for developing plugins.
+
+`example-start-botty.sh` is a Bash script that shows a sample usage of `src/botty.py`. If you edit the script to replace `SLACK_API_TOKEN_GOES_HERE` with an actual API token, you can start Botty simply by running it.
+
+    $ python3 src/botty.py --help
+    Usage: ./botty.py --help
+        Show this help message
+    Usage: ./botty.py
+        Start the Botty chatbot for Slack in testing mode with a console chat interface
+    Usage: ./botty.py SLACK_BOT_TOKEN
+        Start the Botty chatbot for the Slack chat associated with SLACK_BOT_TOKEN, and enter the in-process Python REPL
+        SLACK_BOT_TOKEN is a Slack API token (can be obtained from https://api.slack.com/)
+
+### `src/bot.py`
+
+Implements Slack bot functionality, such as receiving/sending messages, managing the connection to the Slack Realtime Messaging API, looking up users/channels, parsing message formatting/escape sequences, and more. This is encapsulated in the `SlackBot` class, which is intended to be extended to make custom Slack bots.
+
+Also implements a mock Slack bot in the `SlackDebugBot` class, which exposes the same interface as `SlackBot`, but all functionality acts on a simulated Slack chat in the terminal. Replacing `SlackBot` with `SlackDebugBot` allows testing and local development without using the real Slack API at all.
+
+### `src/plugins/*`
+
+Folder in which plugins reside. Each plugin is an importable Python module - a `*.py` file, or a folder containing `__init__.py` as a direct child.
+
+The plugins are imported and registered in `src/botty.py`.
+
+Botty ships with several default plugins. For more information about what they do and how they work, look at their docstrings and source code.
+
+For general information about writing plugins, see the "Writing Plugins" section.
+
+### `utils/download-history.py`
+
+`utils/download-history.py` is a standalone utility that downloads history from all channels in the Slack team associated with a given API token.
+
+If previously downloaded history is present, the new history will be transparently appended to the old history.
+
+    $ python3 src/download-history.py
+    Usage: download-history.py SLACK_API_TOKEN [SAVE_FOLDER]
+        SLACK_API_TOKEN    Slack API token (obtainable from https://api.slack.com/tokens)
+        SAVE_FOLDER        Folder to save messages in (defaults to ./@history)
+
+`example-download-history.sh` is a Bash script that shows a sample usage of this utility. If you edit the script to replace `SLACK_API_TOKEN_GOES_HERE` with an actual Slack API token, you can download history simply by running it.
+
+### `utils/process-history.py`
+
+`utils/process-history.py` is a standalone utility that processes and shows history in-memory. With a variety of filtering options, it is very useful for searching through and filtering messages.
+
+    $ python3 src/process-history.py --help
+    usage: process-history.py [-h] [--history HISTORY] [-f FILTER_FROM]
+                              [-t FILTER_TO] [-c FILTER_CHANNEL] [-u FILTER_USER]
+                              [-i FILTER_TEXT] [-s {time,channel,user,text}]
+                              [-r CONTEXT]
+    
+    Slice and filter Slack chat history.
+    
+    optional arguments:
+      -h, --help            show this help message and exit
+      --history HISTORY     Directory to look for JSON chat history files in
+                            (e.g., "~/.slack-history").
+      -f FILTER_FROM, --filter-from FILTER_FROM
+                            Show only messages at or after a date/time (e.g., "4pm
+                            september 8 2015").
+      -t FILTER_TO, --filter-to FILTER_TO
+                            Show only messages before or at a date/time (e.g.,
+                            "8pm september 9 2015").
+      -c FILTER_CHANNEL, --filter-channel FILTER_CHANNEL
+                            Show only messages within channels with names matching
+                            a specific regular expression (e.g., "general",
+                            "general|random").
+      -u FILTER_USER, --filter-user FILTER_USER
+                            Show only messages by users with usernames or real
+                            names matching a specific regular expression (e.g.,
+                            "anthony", "[AO]nthon[yo] Zh[ao]ng").
+      -i FILTER_TEXT, --filter-text FILTER_TEXT
+                            Show only messages with text matching a specified
+                            regular expression (e.g., "wings?",
+                            "chicken\s+nuggets").
+      -s {time,channel,user,text}, --sort {time,channel,user,text}
+                            Sort the resulting messages by the specified criteria.
+      -r CONTEXT, --context CONTEXT
+                            Show a specified number of surrounding messages around
+                            the channel in each matched message.
+
+`example-process-history.sh` is a Bash script that shows a sample usage of this utility, filtering out messages in the channel `#general` that include the phrase "wing night" or "nuggets", sorted alphabetically by username.
+
+### `utils/export-history-to-db.py`
+
+`utils/export-history-to-db.py` is a standalone utility that, when run, exports an entire history directory (downloaded using something like `utils/download-history.py`) to a single Sqlite3 database, defaulting to `history.db` in the same directory as the script.

--- a/docs/writing-plugins.md
+++ b/docs/writing-plugins.md
@@ -1,0 +1,205 @@
+Plugin Writing Guide
+====================
+
+Overview
+--------
+
+Botty plugins are simply Python classes. By convention, we organize these onto one class per file, and put these files under the `src/plugins` directory.
+
+Plugin classes should inherit from the `BasePlugin` class (from `src/plugins/utilities.py`). This class provides basic functionality like sending messages, looking up user names, and so on.
+
+Plugin classes can optionally implement the `on_step()` method, which is called on every time step (except in the situation described below) - generally several times a second. For multiple plugins, the `on_step` methods are called in the order that the plugins are registered.
+
+If an plugin's `on_step` method returns a truthy value, all plugins registered after it will not have their `on_step` method called for that time step - returning a truthy value stops step processing for the current time step.
+
+Plugin classes can optionally implement the `on_message(message)` method, which is called upon receiving a message (except in the situation described below). For multiple plugins, the `on_message` methods are called in the order that the plugins are registered, and always after `on_step` methods have been called.
+
+If an plugin's `on_message` method returns a truthy value, all plugins registered after it will not have their `on_message` method called for that message - returning a truthy value stops message processing for the current message, representing that the message has been fully handled.
+
+The `message` in `on_message(message)` is a JSON dictionary representing a Slack event. The format of this dictionary is documented in the [Slack API documentation](https://api.slack.com/rtm), under the "Events" section. Generally, most plugins will only care about the [message event type](https://api.slack.com/events/message).
+
+However, it is a good idea to avoid accessing fields of the JSON dictionary directly if possible; if these change in the future, your code could break. If you just need the text, channel, or sender, use the `self.get_message_text(message)`, `self.get_message_channel(message)`, and `self.get_message_sender(message)` methods instead.
+
+Plugins can interact with messages easily using the `self.say` (say something) and `self.react` (react to a message) methods. In message handlers, the `self.respond` (respond to the most recent message) and `sely.reply` (react to the most recent message) methods can be used instead, which are a bit easier to use. Make sure to read the "Types of Text" section to format messages correctly, especially things like URLs and username references.
+
+A Simple Plugin
+---------------
+
+Here is an echo plugin, which simply repeats every message back in the channel that it was sent in. To try this out, save the code as `src/plugins/echo.py`:
+
+```python
+from .utilities import BasePlugin
+class EchoPlugin(BasePlugin):
+    def __init__(self, bot): super().__init__(bot) # initialize the plugin
+    def on_message(self, message):
+        sendable_text = self.get_message_text(message) # get the message text, or `None` for messages that don't have text associated with them
+        if sendable_text is None: return False
+        self.respond(sendable_text) # repeat the message in the same channel
+        return True # mark message as handled, which prevents it from being further processed by other plugins
+```
+
+Plugins are just Python classes, so we also need to register them with Botty. For the echo plugin above, update the body of the `initialize_plugins` function in `src/botty.py`:
+
+```python
+def initialize_plugins(botty):
+    # ...all the plugins that should receive messages before the echo plugin...
+    from plugins.echo import EchoPlugin; botty.register_plugin(EchoPlugin(botty))
+    # ...all the plugins that should receive messages after the echo plugin...
+```
+
+Why does registering a plugin with Botty require updating code, rather than Botty detect plugins automatically? Well, it's more explicit, allows temporary disabling of plugins (by commenting out lines), and avoids messy configuration files.
+
+Message Flows
+-------------
+
+Sometimes, you'll want a plugin that handles multiple messages in a stateful way. For example, consider a questionnaire plugin - when the user says "questions", the plugin asks a few questions before replying with a message. The most obvious way to implement this is to use a state machine:
+
+```python
+from .utilities import BasePlugin
+class QuestionsPlugin(BasePlugin):
+    def __init__(self, bot):
+        super().__init__(bot)
+        self.questions_state = {}
+        self.questions_answer_1, self.questions_answer_2, self.questions_answer_3 = {}, {}, {}
+
+    def on_message(self, message):
+        text, channel, user_id = self.get_message_text(message), self.get_message_channel(message), self.get_message_sender(message)
+        if "questions" in text:
+            self.questions_state[(channel, user_id)] = "QUESTION_1"
+            self.respond("<@{}>, do you enjoy gardening?".format(user_id))
+            return True
+        if self.questions_state.get((channel, user_id)) == "QUESTION_1" and text in {"yes", "no"}:
+            self.questions_state[(channel, user_id)] = "QUESTION_2"
+            self.questions_answer_1[(channel, user_id)] = text
+            self.respond("<@{}>, what's your favourite additive primary color?".format(user_id))
+            return True
+        if self.questions_state.get((channel, user_id)) == "QUESTION_2" and text in {"red", "green", "blue"}:
+            self.questions_state[(channel, user_id)] = "QUESTION_3"
+            self.questions_answer_2[(channel, user_id)] = text
+            self.respond("<@{}>, what number between 1 and 5 inclusive am I thinking of?".format(user_id))
+            return True
+        if self.questions_state.get((channel, user_id)) == "QUESTION_3" and text in {"1", "2", "3", "4", "5"}:
+            del self.questions_state[(channel, user_id)]
+            answer_1, answer_2, answer_3 = self.questions_answer_1[(channel, user_id)], self.questions_answer_2[(channel, user_id)], text
+            self.respond("<@{}>, you {} gardening, like the color {}, and guessed the number {}".format(user_id, "enjoy" if answer_1 == "yes" else "don't enjoy", answer_2, answer_3))
+            return True
+        return False
+```
+
+This does work, but because of the need to manage the questionnaire state, the actual logic is hard to parse. Instead, we can use the `Flow` class from `src/plugins/utilities.py`. This class allows you to write a complex message state machine as a single generator function. Here is the exact same plugin, modified to use `Flow`:
+
+```python
+from .utilities import BasePlugin, Flow
+class QuestionsPlugin(BasePlugin):
+    def __init__(self, bot):
+        super().__init__(bot)
+        self.questions_flow = Flow(self.run_questions)
+
+    def run_questions(self, user_id): # generator function to demonstrate multi-message flows
+        self.respond("<@{}>, do you enjoy gardening?".format(user_id))
+        answer_1 = yield True # yield True because we successfully handled the message that started this flow
+        while answer_1 not in {"yes", "no"}: answer_1 = yield False # keep ignoring user messages until it's one we expect
+
+        self.respond("<@{}>, what's your favourite additive primary color?".format(user_id))
+        answer_2 = yield True # yield True because we successfully handled answer 1, and get the user's next message as well
+        while answer_2 not in {"red", "green", "blue"}: answer_2 = yield False # keep ignoring user messages until it's one we expect
+
+        self.respond("<@{}>, what number between 1 and 5 inclusive am I thinking of?".format(user_id))
+        answer_3 = yield True # yield True because we successfully handled answer 2, and get the user's next message as well
+        while answer_3 not in {"1", "2", "3", "4", "5"}: answer_3 = yield False # keep ignoring user messages until it's one we expect
+
+        self.respond("<@{}>, you {} gardening, like the color {}, and guessed the number {}".format(user_id, "enjoy" if answer_1 == "yes" else "don't enjoy", answer_2, answer_3))
+        return True # return True because answer 3 we successfully handled answer 3
+
+    def on_message(self, message):
+        text, channel, user_id = self.get_message_text(message), self.get_message_channel(message), self.get_message_sender(message)
+        if "questions" in text: # start the questionnaire
+            self.questions_flow.start((channel, user_id), user_id) # start the flow - run the generator up to the first yield
+        return self.questions_flow.step((channel, user_id), text) # run the next step in the flow - this returns whatever value was yielded or returned from the generator function
+```
+
+With `Flow`, the logic is a lot easier to see: ask questions, wait for responses, then do something afterwards. For small examples like this one, the code is still about the same length, but for more complicated flows, the `Flow` class can make your code significantly shorter and more readable.
+
+What is a flow key? A flow key represents the thing that each individual generator iterator is associated with. For example, `QuestionsPlugin` above uses channel and user ID tuples as its flow key. That means there can be a unique questionnaire for each combination of users and channels - each user can have their own instance of the questionnaire, in every channel.
+
+When does each part of the generator function run? The part before the first `yield` is run upon calling `some_flow_instance.start(...)`. Each call to `some_flow_instance.step(...)` will run the next piece of code between `yield` or `return` statements. Note that there can be multiple generator iterators resulting from a single generator function all running at once; each flow has one generator function, but can also have one generator iterator for every flow key. For example, if the flow keys are channels, then there can be one generator iterator for each channel.
+
+What should the generator function return/yield each time? The general rule is "return a truthy value if and only if the previous return value of `yield` was successfully handled (or if there is no previous `yield`)". So the first `yield` in the function should generally be `yield True`, because there was no previous `yield`. Note that `return SOME_VALUE` and `yield SOME_VALUE` have exactly the same meaning, except the former also ends the flow.
+
+Why do we often return the value of `some_flow_instance.step(...)` at the end of our `on_message` methods? When the generator function returns or yields a value, this is because we called `some_flow_instance.step(...)` to send in some data. `some_flow_instance.step(...)` will then return that returned/yielded value from the generator function, which represents whether the flow successfully handled the sent-in data. If the sent-in data represents a single message, the return value then means "whether the flow handled the message". Note that if you have multiple concurrent flows and the sent-in data for each one represents a single message, you can return `any(flow_instance.step(...) for flow_instance in list_of_flow_instances)`, which means "whether any of the flows handled the message".
+
+Here's another example of `Flow`, demonstrating more complex multi-message interactions. When a user says "barrier", the plugin activates a barrier, and then waits for 5 different people to say "ready" before responding with a message:
+
+```python
+from .utilities import BasePlugin
+class BarrierPlugin(BasePlugin):
+    def __init__(self, bot):
+        super().__init__(bot)
+        self.barrier_flow = Flow(self.run_barrier)
+        self.barrier_size = 5 # this many people must be ready before we can proceed
+
+    def run_barrier(self, extra_data): # generator function to demonstrate mutli-message flows
+        self.respond_raw("No people ready; barrier holding")
+        ready_users = set()
+        while len(ready_users) < self.barrier_size:
+            text, user = yield True # yield True because we successfully handled the last-retrieved message, and get the user's next message as well
+            while "ready" not in text: text, user = yield False # keep ignoring user messages until it's one we expect
+            ready_users.add(user) # mark the user as ready
+            self.respond_raw("{} people ready; barrier holding".format(len(ready_users)))
+        self.respond_raw("Party ready; barrier released!") # 5 different people have said "ready"
+        return True # return True because we successfully handled the last "ready" message
+
+    def on_message(self, message):
+        text, channel, user = self.get_message_text(message), self.get_message_channel(message), self.get_message_sender(message)
+        if "barrier" in text:
+            if self.barrier_flow.is_running(channel): # don't allow a new barrier to be activated if there already is one
+                self.respond("There's already a barrier active!")
+                return True
+            self.barrier_flow.start(channel)
+        return self.barrier_flow.step(channel, (text, user)) # this returns whatever value was yielded or returned from the generator function
+```
+
+Types of Text
+-------------
+
+There are actually three different formats for text in Slack messages:
+
+* **Sendable format** is the format of text that is suitable for sending as the body of messages in the Slack API, such as for message contents.
+    * **Sendable text** is text that follows the sendable format.
+    * Sendable text should generally be considered opaque, since you generally won't want to go through the effort of dealing with the syntax.
+    * The main difference between sendable text and server text is that sendable text has bare links, while server text surrounds links with `<` and `>`.
+    * That means that if you send server text instead of sendable text, links will have angle brackets around them.
+* **Plain format** is the lack of any fixed format.
+    * **Plain text** is text that has no fixed format - it can contain anything.
+    * The main difference between plain text and sendable text is that sendable text has the `<`, `>`, and `&` characters HTML-escaped, while plain text does not.
+* **Server format** is the format of text received from the Slack API, such as for message contents.
+    * **Server text** is text that follows server format.
+    * Plugins generally don't have to care about server text because functions in the plugin API that deal with text will return either sendable or plain text.
+
+Sendable text should be used for sending back parts of Slack messages that we receive, and plain text should be used for everything else. This is because **sendable text can represent more information than plain text can**, such as channel/user references, links, and more. Therefore, **converting sendable text to plain text can lose information**.
+
+However, **sendable text has special formatting that needs to be explicitly handled in code**. For things like sending the text to a search engine as a query, it is better to send the plain text version, since it will not have any of the special formatting.
+
+For example, if someone messages "@onthono in #general" (a username reference and a channel reference) to Botty, Botty might receive the sendable text `<@U123456> in <#C123456>`. If you convert this to plain text, it becomes `@onthono in #general`, as you would expect. In other words, **the plain text version of a message is what a user would type to send that message, while the sendable text version is what the server actually sees**.
+
+Suppose we have a plugin that attempts to evaluate all messages as Python code and responds with the results:
+
+```python
+from .utilities import BasePlugin
+class ArithmeticPlugin(BasePlugin):
+    def __init__(self, bot):
+        super().__init__(bot)
+
+    def on_message(self, message):
+        sendable_text = self.get_message_text(message)
+        if sendable_text is None: return False
+        text = self.sendable_text_to_text(sendable_text) # convert sendable text to plain text
+
+        try: result = str(eval(text)) # we evaluate the plain text `text` rather than the sendable text `sendable_text`
+        except Exception as e: result = str(e)
+        sendable_result = self.text_to_sendable_text(result)
+
+        # we send `sendable_text` instead of `text` to preserve sendable formatting that is lost when converting sendable text to plain text
+        self.respond("{} :point_right: {}".format(sendable_text, sendable_result))
+        return True
+```

--- a/src/botty.py
+++ b/src/botty.py
@@ -5,6 +5,26 @@ from collections import deque
 
 from bot import SlackBot
 
+# process settings
+#logging.basicConfig(stream=sys.stdout, level=logging.INFO, format="%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+logging.basicConfig(filename="botty.log", level=logging.INFO, format="%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+
+def initialize_plugins(botty):
+    """Import, register, and initialize Botty plugins. Edit the body of this function to change which plugins are loaded."""
+    from plugins.arithmetic import ArithmeticPlugin; botty.register_plugin(ArithmeticPlugin(botty))
+    from plugins.timezones import TimezonesPlugin; botty.register_plugin(TimezonesPlugin(botty))
+    from plugins.poll import PollPlugin; botty.register_plugin(PollPlugin(botty))
+    from plugins.wiki import WikiPlugin; botty.register_plugin(WikiPlugin(botty))
+    from plugins.haiku import HaikuPlugin; botty.register_plugin(HaikuPlugin(botty))
+    from plugins.personality import PersonalityPlugin; botty.register_plugin(PersonalityPlugin(botty))
+    from plugins.events import EventsPlugin; botty.register_plugin(EventsPlugin(botty))
+    from plugins.now_i_am_dude import NowIAmDudePlugin; botty.register_plugin(NowIAmDudePlugin(botty))
+    from plugins.generate_text import GenerateTextPlugin; botty.register_plugin(GenerateTextPlugin(botty))
+    from plugins.big_text import BigTextPlugin; botty.register_plugin(BigTextPlugin(botty))
+    from plugins.uw_courses import UWCoursesPlugin; botty.register_plugin(UWCoursesPlugin(botty))
+    from plugins.spaaace import SpaaacePlugin; botty.register_plugin(SpaaacePlugin(botty))
+    from plugins.agario import AgarioPlugin; botty.register_plugin(AgarioPlugin(botty))
+
 if len(sys.argv) > 2 or (len(sys.argv) == 2 and sys.argv[1] in {"--help", "-h", "-?"}):
     print("Usage: {} --help".format(sys.argv[0]))
     print("    Show this help message")
@@ -15,9 +35,6 @@ if len(sys.argv) > 2 or (len(sys.argv) == 2 and sys.argv[1] in {"--help", "-h", 
     print("    SLACK_BOT_TOKEN is a Slack API token (can be obtained from https://api.slack.com/)")
     sys.exit(1)
 
-# process settings
-#logging.basicConfig(stream=sys.stdout, level=logging.INFO, format="%(asctime)s [%(levelname)s] %(name)s: %(message)s")
-logging.basicConfig(filename="botty.log", level=logging.INFO, format="%(asctime)s [%(levelname)s] %(name)s: %(message)s")
 DEBUG = len(sys.argv) < 2
 if DEBUG:
     from bot import SlackDebugBot as SlackBot
@@ -104,45 +121,7 @@ class Botty(SlackBot):
         return self.unreact(self.last_message_channel_id, self.last_message_timestamp, emoticon)
 
 botty = Botty(SLACK_TOKEN)
-
-from plugins.arithmetic import ArithmeticPlugin
-botty.register_plugin(ArithmeticPlugin(botty))
-
-from plugins.timezones import TimezonesPlugin
-botty.register_plugin(TimezonesPlugin(botty))
-
-from plugins.poll import PollPlugin
-botty.register_plugin(PollPlugin(botty))
-
-from plugins.wiki import WikiPlugin
-botty.register_plugin(WikiPlugin(botty))
-
-from plugins.haiku import HaikuPlugin
-botty.register_plugin(HaikuPlugin(botty))
-
-from plugins.personality import PersonalityPlugin
-botty.register_plugin(PersonalityPlugin(botty))
-
-from plugins.events import EventsPlugin
-botty.register_plugin(EventsPlugin(botty))
-
-from plugins.now_i_am_dude import NowIAmDudePlugin
-botty.register_plugin(NowIAmDudePlugin(botty))
-
-from plugins.generate_text import GenerateTextPlugin
-botty.register_plugin(GenerateTextPlugin(botty))
-
-from plugins.big_text import BigTextPlugin
-botty.register_plugin(BigTextPlugin(botty))
-
-from plugins.uw_courses import UWCoursesPlugin
-botty.register_plugin(UWCoursesPlugin(botty))
-
-from plugins.spaaace import SpaaacePlugin
-botty.register_plugin(SpaaacePlugin(botty))
-
-from plugins.agario import AgarioPlugin
-botty.register_plugin(AgarioPlugin(botty))
+initialize_plugins(botty)
 
 # start administrator console in production mode
 if not DEBUG:


### PR DESCRIPTION
Inspired by a certain fish-themed IRC bot back in my Freenode days, I've been meaning to add generator-based message flows for a while now.

The new `Flow` class allows you to write async code that simply sees a stream of messages, rather than having to handle each message individually. That means places that would often require a state machine and lots of state can simply be written with Python loops and conditionals over the message stream.

Also, the docs are split off from the README, and expanded to make it easier for developers to get started.
